### PR TITLE
Update kernel to 4.15rc9-26-01-2018 and bigger improve install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd linux-sunxi/
 make clean
 make -j `getconf _NPROCESSORS_ONLN` deb-pkg LOCALVERSION=-custom-matlala-DD-MM-YYYY
 ```
-After few minutes (or hour, depend on HW), compress all generated .deb files into a tar.gz archive with name "gpd-pocket-kernel-files.tar.gz", put it into /tmp folder and run `install-kernel.sh`.
+After few minutes (or hour, depend on HW), compress all generated .deb files into a tar.gz archive with name "gpd-pocket-kernel-files.tar.gz", put it into `/tmp` directory and run `install-kernel.sh`.
 ```
 cd /tmp/gpd-pocket-kernel
 sudo dpkg -i *.deb
@@ -54,4 +54,4 @@ sudo update-grub
 ```
 
 # Older kernel relases
-If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script can install it automatically, if you put downloaded kernel archive into /tmp directory and run `install-kernel.sh`.
+If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script can install it automatically, if you put downloaded kernel archive into `/tmp` directory and run `install-kernel.sh`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd linux-sunxi/
 make clean
 make -j `getconf _NPROCESSORS_ONLN` deb-pkg LOCALVERSION=-custom-matlala-DD-MM-YYYY
 ```
-After few minutes (or hour), copy generated .deb files to another direcroty (for exmaple /tmp/gpd-pocket-kernel) and install with
+After few minutes (or hour, depend on HW), compress all generated .deb files into a tar.gz archive with name "gpd-pocket-kernel-files.tar.gz", put it into /tmp folder and run update script install-kernel.sh.
 ```
 cd /tmp/gpd-pocket-kernel
 sudo dpkg -i *.deb
@@ -54,4 +54,4 @@ sudo update-grub
 ```
 
 # Older kernel relases
-If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c) and install manually.
+If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script ca install it automatically, if you put downloaded kernel archive into /tmp directory and run update script install-kernel.sh.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ sudo update-grub
 ```
 
 # Older kernel relases
-If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script ca install it automatically, if you put downloaded kernel archive into /tmp directory and run update script install-kernel.sh.
+If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script can install it automatically, if you put downloaded kernel archive into /tmp directory and run update script install-kernel.sh.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Fisrt, install tools and clone Hans repo
 sudo apt-get install build-essential git libncurses5-dev libssl-dev libelf-dev
 git clone https://github.com/jwrdegoede/linux-sunxi.git
 ```
-Copy and overwrite my .config to directory ./linux-sunxi
+Copy and overwrite my `.config` to directory ./linux-sunxi
 
 If you have already donwloaded the repository, you can update it with latest commits issuing:
 ```
@@ -46,7 +46,7 @@ cd linux-sunxi/
 make clean
 make -j `getconf _NPROCESSORS_ONLN` deb-pkg LOCALVERSION=-custom-matlala-DD-MM-YYYY
 ```
-After few minutes (or hour, depend on HW), compress all generated .deb files into a tar.gz archive with name "gpd-pocket-kernel-files.tar.gz", put it into /tmp folder and run update script install-kernel.sh.
+After few minutes (or hour, depend on HW), compress all generated .deb files into a tar.gz archive with name "gpd-pocket-kernel-files.tar.gz", put it into /tmp folder and run `install-kernel.sh`.
 ```
 cd /tmp/gpd-pocket-kernel
 sudo dpkg -i *.deb
@@ -54,4 +54,4 @@ sudo update-grub
 ```
 
 # Older kernel relases
-If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script can install it automatically, if you put downloaded kernel archive into /tmp directory and run update script install-kernel.sh.
+If you want download and install my older kernel version, you can download from my [Google drive](https://drive.google.com/drive/folders/1XmwYXIRxsdo4GZti8woYtvhOI1pvXB9c). My script can install it automatically, if you put downloaded kernel archive into /tmp directory and run `install-kernel.sh`.

--- a/install-kernel.sh
+++ b/install-kernel.sh
@@ -1,15 +1,32 @@
 #This script automatically download and install/update my kernel
 #!/bin/bash
 
+#gpd-pocket-kernel-4.15rc9-26-01-2018
+URL_ID="1AfqTUe3vsdUq8CcLpLirrancsnlI2K-f"
+
 CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
+FILE_COUNT="$(find /tmp/ -maxdepth 1 -type f -name 'gpd-pocket-kernel-*.tar.gz' | wc -l)"
+
+cd /tmp
+
+if [ -d "gpd-pocket-kernel" ]; then
+	rm -rf /tmp/gpd-pocket-kernel
+fi
 
 mkdir -p /tmp/gpd-pocket-kernel
-cd /tmp/gpd-pocket-kernel
 
-if [ ! -f "gpd-pocket-kernel-files.tar.gz" ]; then
+if [ $FILE_COUNT -eq 1 ]; then
+	 echo "Manual downloaded kernel found..."	
+	 mv gpd-pocket-kernel-*.tar.gz /tmp/gpd-pocket-kernel/gpd-pocket-kernel-files.tar.gz	
+elif [ $FILE_COUNT -gt 1 ]; then
+	echo "Manual downloaded kernel found, but more than one. Please leave only one in /tmp directory!"		 
+else
 	 echo "Downloading kernel files...."
-	 curl -L https://drive.google.com/uc?id=13spiPSa5057JIcGoC811xyH25v7Cd4K3 -o "gpd-pocket-kernel-files.tar.gz"
+	 cd /tmp/gpd-pocket-kernel
+	 curl -L https://drive.google.com/uc?id=$URL_ID -o "gpd-pocket-kernel-files.tar.gz"
+	 
 fi
+
 
 echo "Extracting kernel files..."
 tar -xvzf  gpd-pocket-kernel-*.tar.gz 
@@ -20,7 +37,6 @@ sudo dpkg -i *.deb
 echo "Update grub..."
 sudo update-grub
 
-rm *.deb gpd-pocket-kernel-files.tar.gz 
 rm -rfd /tmp/gpd-pocket-kernel
 
 cd $CURRENT_DIR


### PR DESCRIPTION
- Update kernel to 4.15rc9-26-01-2018

- I add check if existing manual downloaded kernel archive in /tmp directory. If you want install older kernel, you need only download to /tmp directory with original name. 

- If you have more than 1 kernel archive in /tmp directory, script report it and exit, install will be canceled.

- New logic for easier updates and check it. Version and part of URL is on very first lines in my script.